### PR TITLE
Remove Paste and API links from navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,7 @@
         <div class="card-body">
           <ul class="nav nav-pills">
             <li class="nav-item"><a class="nav-link active" href="https://addons.vevioz.com"><i class="fas fa-home"></i></a></li>
-            <li class="nav-item"><a class="nav-link" href="https://downloader.vevioz.com" target="_blank"><i class="fa-brands fa-youtube"></i> <b>PASTE</b></a></li>
             <li class="nav-item"><a class="nav-link" href="https://www.paypal.com/paypalme/vevioz" target="_blank"><i class="fa-brands fa-paypal"></i> <b>DONATE</b></a></li>
-            <li class="nav-item"><a class="nav-link" href="https://api.vevioz.com" target="_blank"><i class="fa-solid fa-code"></i> <b>API</b></a></li>
             <li class="nav-item"><a class="nav-link" href="https://www.vevioz.com/login-with.php?provider=Google" target="_blank"><i class="fa-solid fa-right-to-bracket"></i> <b>LOGIN</b></a></li>
             <li class="nav-item"><a class="nav-link" href="https://www.vevioz.com/register" target="_blank"><i class="fa-solid fa-user-plus"></i> <b>SIGNUP</b></a></li>
             <li class="nav-item"><a class="nav-link" href="https://www.vevioz.com/terms/privacy-policy" target="_blank"><i class="fa-solid fa-star"></i> <b>PRIVACY</b></a></li>


### PR DESCRIPTION
## Summary
- remove the Paste and API navigation items from the top navbar so they no longer appear

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfdb12eaa08326885c9946fc1fef20