### PR TITLE
Remove Plyr dependency and update player styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,37 @@
 <title>YouTube Downloader Addons</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/plyr@3/dist/plyr.css" />
 <style>
   body { background-color: #000; }
   .player-shell { max-width: 100%; width: 100%; margin: 0 auto; }
-  .player-shell .plyr__video-embed { width: 100%; aspect-ratio: 16/9; border-radius: .5rem; overflow: hidden; }
+  .player-shell .player-embed {
+    position: relative;
+    width: 100%;
+    border-radius: .5rem;
+    overflow: hidden;
+    background-color: #000;
+  }
+  .player-shell .player-embed::before {
+    content: "";
+    display: block;
+    padding-top: 56.25%;
+  }
+  .player-shell .player-embed iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+  @supports (aspect-ratio: 16 / 9) {
+    .player-shell .player-embed {
+      aspect-ratio: 16 / 9;
+    }
+    .player-shell .player-embed::before {
+      display: none;
+      padding-top: 0;
+    }
+  }
   /* Fix downloader area: no inner scrollbars */
   .dl-wrapper { width: 100%; }
   .dl-wrapper iframe { border: none; overflow: hidden; width: 100%; height: 1800px; }
@@ -59,7 +85,7 @@
 
         <div class="card-body mb-0">
           <div class="w-100 player-shell">
-            <div class="plyr__video-embed" id="plyr-wrapper">
+            <div class="player-embed" id="plyr-wrapper">
               <iframe id="player"
                 src="https://www.youtube-nocookie.com/embed/F0LqKYCnQ_Y?autoplay=1&mute=0"
                 allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
@@ -97,8 +123,6 @@
     </div>
   </div>
 </div>
-
-<script src="https://cdn.jsdelivr.net/npm/plyr@3/dist/plyr.polyfilled.min.js"></script>
 
 <!-- === START: LOGIC ADDED (tidak mengubah desain) === -->
 <script>
@@ -204,10 +228,5 @@ function extractYouTubeID(input) {
 </script>
 <!-- === END: LOGIC ADDED === -->
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  new Plyr('#plyr-wrapper', { autoplay:true, muted:true });
-});
-</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the Plyr CSS/JS assets and the related DOMContentLoaded initializer
- replace the Plyr embed wrapper with a custom player-embed class that keeps the iframe responsive at 16:9

## Testing
- curl -I http://localhost:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68cfdfbab0288326827521019fd5736d